### PR TITLE
Added ExternalContentLibrary references to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ cm-8.1:
  - Microsoft.OData.Edm.dll
  - Microsoft.Spatial.dll
  - Newtonsoft.Json.dll
+ - Tridion.ExternalContentLibrary.dll
+ - Tridion.ExternalContentLibrary.V2.dll
 
 
 Support


### PR DESCRIPTION
DD4T.Templates.Base is pulled in via Nuget, and references the two ECL assemblies. As these are not in a public Nuget repo, the DD4T package doesn't reference them so they need to be in the list of dlls that are added by hand.