### PR TITLE
Issue #29 - Fix for Sitemap containing unpublished items

### DIFF
--- a/Sdl.Web.Tridion.Templates/Templates/GenerateSitemap.cs
+++ b/Sdl.Web.Tridion.Templates/Templates/GenerateSitemap.cs
@@ -237,8 +237,16 @@ namespace Sdl.Web.Tridion.Templates
 
         private bool IsPublished(Page page)
         {
+            if (Engine.PublishingContext?.PublicationTarget != null)
+            {
+                return PublishEngine.IsPublished(page, Engine.PublishingContext.PublicationTarget, true);
+            }
+            if (Engine.PublishingContext?.TargetType != null)
+            {
+                return PublishEngine.IsPublished(page, Engine.PublishingContext.TargetType, true);
+            }
             //For preview we always return true - to help debugging
-            return (Engine.PublishingContext?.PublicationTarget == null) || PublishEngine.IsPublished(page, Engine.PublishingContext.PublicationTarget);
+            return true;
         }
 
         private static bool IsVisible(string title)


### PR DESCRIPTION
Check if a page is published *only* in the context publication and not in *any* publication when generating the navigation/sitemap