### PR TITLE
Fully expand entity models in RTF fields

### DIFF
--- a/Sdl.Web.Tridion.Templates.R2/Data/DataModelBuilder.cs
+++ b/Sdl.Web.Tridion.Templates.R2/Data/DataModelBuilder.cs
@@ -217,7 +217,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
             if (xmlElement.SelectSingleElement("xhtml:*") != null)
             {
                 // XHTML field
-                return BuildRichTextModel(xmlElement);
+                return BuildRichTextModel(xmlElement, expandLinkDepth);
             }
 
             if (xmlElement.SelectSingleElement("*") != null)
@@ -292,7 +292,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
             return Pipeline.CreateKeywordModel(linkedKeyword, expandLinkDepth - 1);
         }
 
-        protected RichTextData BuildRichTextModel(XmlElement xhtmlElement)
+        protected RichTextData BuildRichTextModel(XmlElement xhtmlElement, int expandLinkDepth = 0)
         {
             XmlDocument xmlDoc = xhtmlElement.OwnerDocument;
             IList<EntityModelData> embeddedEntities = new List<EntityModelData>();
@@ -301,7 +301,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
                 Component linkedComponent = Pipeline.Session.GetObject(xlinkElement) as Component;
                 if (xlinkElement.LocalName == "img" || ShouldBeEmbedded(linkedComponent))
                 {
-                    EntityModelData embeddedEntity = Pipeline.CreateEntityModel(linkedComponent, ct: null, expandLinkDepth: 0);
+                    EntityModelData embeddedEntity = Pipeline.CreateEntityModel(linkedComponent, ct: null, expandLinkDepth: expandLinkDepth);
 
                     // Map each attribute to a metadata field
 


### PR DESCRIPTION
Allows for entity models in RTF to be fully expanded - based upon the expandLinkDepth set in a template.
Previously a component embedded in an RTF would not be fully expanded so you couldn't get to any fields in a linked component in your embedded component.
This is useful for example, in a situation where the component your embedding in an RTF links to an ECL asset and want the metadata.