### PR TITLE
Implement customizable binary filenames without TCM URI

### DIFF
--- a/Sdl.Web.Tridion.Templates.R2/Data/DataModelBuilderSettings.cs
+++ b/Sdl.Web.Tridion.Templates.R2/Data/DataModelBuilderSettings.cs
@@ -32,5 +32,10 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
         ///         E.g: http://www.sdl.com/web/schemas/core:Article
         /// </summary>
         public List<string> SchemasForRichTextEmbed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the a list of schema names used to determine if multimedia link should use the url as is from the binary filename (no tcm-id)
+        /// </summary>
+        public List<string> SchemasForAsIsMultimediaUrls { get; set; }
     }
 }

--- a/Sdl.Web.Tridion.Templates.R2/Data/DefaultModelBuilder.cs
+++ b/Sdl.Web.Tridion.Templates.R2/Data/DefaultModelBuilder.cs
@@ -88,9 +88,9 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
                 StructureGroupId = GetDxaIdentifier(structureGroup),
                 SchemaId = GetDxaIdentifier(page.MetadataSchema),
                 Meta = null, // Default Model builder does not set PageModel.Meta; see DefaultPageMetaModelBuilder.
-                Title = StripSequencePrefix(page.Title, out sequencePrefix) , // See DefaultPageMetaModelBuilder
+                Title = StripSequencePrefix(page.Title, out sequencePrefix), // See DefaultPageMetaModelBuilder
                 UrlPath = GetUrlPath(page),
-                Regions = regionModels.Values.ToList(),                
+                Regions = regionModels.Values.ToList(),
                 Metadata = pageModelMetadata,
                 MvcData = GetPageMvcData(pt),
                 HtmlClasses = GetHtmlClasses(pt),
@@ -197,7 +197,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
 
             return new BinaryContentData
             {
-                Url = Pipeline.RenderedItem.AddBinary(component).Url,
+                Url = AddBinary(component).Url,
                 FileName = binaryContent.Filename,
                 FileSize = binaryContent.Size,
                 MimeType = binaryContent.MultimediaType.MimeType
@@ -313,7 +313,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
                 Page includePage;
                 try
                 {
-                    includePage = (Page) Pipeline.Session.GetObject(includePageId);
+                    includePage = (Page)Pipeline.Session.GetObject(includePageId);
                     includePage.Load(LoadFlags.None); // Force load the Page
                 }
                 catch (Exception ex)
@@ -370,7 +370,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
                 {
                     webDavUrlBuilder.Append("_System");
                 }
-                else if (i == pathSegments.Length -1)
+                else if (i == pathSegments.Length - 1)
                 {
                     // Last path segment (representing the Page itself)
                     // Convert dashes to spaces and capitalize each name segment.
@@ -689,7 +689,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
                 Id = GetDxaIdentifier(ct),
                 Namespace = GetNamespace(ct)
             };
-           
+
             if (ct.Metadata == null || ct.MetadataSchema == null) return componentTemplateData;
             componentTemplateData.Title = ct.Title;
             componentTemplateData.RevisionDate = ct.RevisionDate;
@@ -700,7 +700,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Data
 
         private FolderData GetFolderData(Component component)
         {
-            Folder folder = (Folder) component.OrganizationalItem;
+            Folder folder = (Folder)component.OrganizationalItem;
             return new FolderData
             {
                 Id = folder.Id?.ItemId.ToString(),

--- a/Sdl.Web.Tridion.Templates.R2/Resources/GenerateEntityModelParameters.xsd
+++ b/Sdl.Web.Tridion.Templates.R2/Resources/GenerateEntityModelParameters.xsd
@@ -1,36 +1,38 @@
 ﻿<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"  targetNamespace="http://www.sdl.com/web/schemas/dynamiccomponent" xmlns="http://www.sdl.com/web/schemas/dynamiccomponent" xmlns:tcmi="http://www.tridion.com/ContentManager/5.0/Instance" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified">
-    <xsd:import namespace="http://www.tridion.com/ContentManager/5.0/Instance" schemaLocation="cm_xml_inst.xsd"></xsd:import>
-    <xsd:annotation>
-        <xsd:appinfo>
-            <tcm:Labels xmlns:tcm="http://www.tridion.com/ContentManager/5.0">
-                <tcm:Label ElementName="includeComponentTemplateData" Metadata="false">Include Component Template related data</tcm:Label>
-                <tcm:Label ElementName="expandLinkDepth" Metadata="false">Depth to expand Component/Keyword links</tcm:Label>
-                <tcm:Label ElementName="modelBuilderTypeNames" Metadata="false">Type names of Model Builders to use (separated by semicolons)</tcm:Label>
-                <tcm:Label ElementName="schemasToEmbedInRichText" Metadata="false">List of schema identifiers (use either schema title or a namespace Uri with optional root element name (NamespaceUri:RootElementName) which will result in embedded items in Rich text fields (separated by semicolons)</tcm:Label>
-            </tcm:Labels>
-        </xsd:appinfo>
-    </xsd:annotation>
-    <xsd:element name="Parameters">
-        <xsd:complexType>
-            <xsd:sequence>
-                <xsd:element name="includeComponentTemplateData" minOccurs="0" maxOccurs="1">
-                  <xsd:annotation>
-                    <xsd:appinfo>
-                      <tcm:Size xmlns:tcm="http://www.tridion.com/ContentManager/5.0">1</tcm:Size>
-                      <tcm:listtype xmlns:tcm="http://www.tridion.com/ContentManager/5.0">select</tcm:listtype>
-                    </xsd:appinfo>
-                  </xsd:annotation>
-                  <xsd:simpleType>
-                    <xsd:restriction base="xsd:normalizedString">
-                      <xsd:enumeration value="true"></xsd:enumeration>
-                      <xsd:enumeration value="false"></xsd:enumeration>
-                    </xsd:restriction>
-                  </xsd:simpleType>
-                </xsd:element>
-                <xsd:element name="expandLinkDepth" minOccurs="0" maxOccurs="1" type="xsd:integer" />
-                <xsd:element name="modelBuilderTypeNames" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
-                <xsd:element name="schemaToEmbedInRichText" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
-            </xsd:sequence>
-        </xsd:complexType>
-    </xsd:element>
+  <xsd:import namespace="http://www.tridion.com/ContentManager/5.0/Instance" schemaLocation="cm_xml_inst.xsd"></xsd:import>
+  <xsd:annotation>
+    <xsd:appinfo>
+      <tcm:Labels xmlns:tcm="http://www.tridion.com/ContentManager/5.0">
+        <tcm:Label ElementName="includeComponentTemplateData" Metadata="false">Include Component Template related data</tcm:Label>
+        <tcm:Label ElementName="expandLinkDepth" Metadata="false">Depth to expand Component/Keyword links</tcm:Label>
+        <tcm:Label ElementName="modelBuilderTypeNames" Metadata="false">Type names of Model Builders to use (separated by semicolons)</tcm:Label>
+        <tcm:Label ElementName="schemasToEmbedInRichText" Metadata="false">List of schema identifiers (use either schema title or a namespace Uri with optional root element name (NamespaceUri:RootElementName) which will result in embedded items in Rich text fields (separated by semicolons)</tcm:Label>
+        <tcm:Label ElementName="schemasForAsIsMultimediaUrls" Metadata="false">List of schema names which will result in multimedia links that should use the url as is from the binary filename without tcm-id</tcm:Label>
+      </tcm:Labels>
+    </xsd:appinfo>
+  </xsd:annotation>
+  <xsd:element name="Parameters">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="includeComponentTemplateData" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:appinfo>
+              <tcm:Size xmlns:tcm="http://www.tridion.com/ContentManager/5.0">1</tcm:Size>
+              <tcm:listtype xmlns:tcm="http://www.tridion.com/ContentManager/5.0">select</tcm:listtype>
+            </xsd:appinfo>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:normalizedString">
+              <xsd:enumeration value="true"></xsd:enumeration>
+              <xsd:enumeration value="false"></xsd:enumeration>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element name="expandLinkDepth" minOccurs="0" maxOccurs="1" type="xsd:integer" />
+        <xsd:element name="modelBuilderTypeNames" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
+        <xsd:element name="schemaToEmbedInRichText" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
+        <xsd:element name="schemasForAsIsMultimediaUrls" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/Sdl.Web.Tridion.Templates.R2/Resources/GeneratePageModelParameters.xsd
+++ b/Sdl.Web.Tridion.Templates.R2/Resources/GeneratePageModelParameters.xsd
@@ -1,21 +1,23 @@
 ﻿<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"  targetNamespace="http://www.sdl.com/web/schemas/dynamicpage" xmlns="http://www.sdl.com/web/schemas/dynamicpage" xmlns:tcmi="http://www.tridion.com/ContentManager/5.0/Instance" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified">
-    <xsd:import namespace="http://www.tridion.com/ContentManager/5.0/Instance" schemaLocation="cm_xml_inst.xsd"></xsd:import>
-    <xsd:annotation>
-        <xsd:appinfo>
-            <tcm:Labels xmlns:tcm="http://www.tridion.com/ContentManager/5.0">
-                <tcm:Label ElementName="expandLinkDepth" Metadata="false">Depth to expand Component/Keyword links</tcm:Label>
-                <tcm:Label ElementName="modelBuilderTypeNames" Metadata="false">Type names of Model Builders to use (separated by semicolons)</tcm:Label>
-                <tcm:Label ElementName="schemasToEmbedInRichText" Metadata="false">List of schema identifiers (use either schema title or a namespace Uri with optional root element name (NamespaceUri:RootElementName) which will result in embedded items in Rich text fields (separated by semicolons)</tcm:Label>
-            </tcm:Labels>
-        </xsd:appinfo>
-    </xsd:annotation>
-    <xsd:element name="Parameters">
-        <xsd:complexType>
-            <xsd:sequence>
-                <xsd:element name="expandLinkDepth" minOccurs="0" maxOccurs="1" type="xsd:integer" />
-                <xsd:element name="modelBuilderTypeNames" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
-                <xsd:element name="schemasToEmbedInRichText" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
-            </xsd:sequence>
-        </xsd:complexType>
-    </xsd:element>
+  <xsd:import namespace="http://www.tridion.com/ContentManager/5.0/Instance" schemaLocation="cm_xml_inst.xsd"></xsd:import>
+  <xsd:annotation>
+    <xsd:appinfo>
+      <tcm:Labels xmlns:tcm="http://www.tridion.com/ContentManager/5.0">
+        <tcm:Label ElementName="expandLinkDepth" Metadata="false">Depth to expand Component/Keyword links</tcm:Label>
+        <tcm:Label ElementName="modelBuilderTypeNames" Metadata="false">Type names of Model Builders to use (separated by semicolons)</tcm:Label>
+        <tcm:Label ElementName="schemasToEmbedInRichText" Metadata="false">List of schema identifiers (use either schema title or a namespace Uri with optional root element name (NamespaceUri:RootElementName) which will result in embedded items in Rich text fields (separated by semicolons)</tcm:Label>
+        <tcm:Label ElementName="schemasForAsIsMultimediaUrls" Metadata="false">List of schema names which will result in multimedia links that should use the url as is from the binary filename without tcm-id</tcm:Label>
+      </tcm:Labels>
+    </xsd:appinfo>
+  </xsd:annotation>
+  <xsd:element name="Parameters">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="expandLinkDepth" minOccurs="0" maxOccurs="1" type="xsd:integer" />
+        <xsd:element name="modelBuilderTypeNames" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
+        <xsd:element name="schemasToEmbedInRichText" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
+        <xsd:element name="schemasForAsIsMultimediaUrls" minOccurs="0" maxOccurs="1" type="xsd:normalizedString" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/Sdl.Web.Tridion.Templates.R2/TemplateR2Base.cs
+++ b/Sdl.Web.Tridion.Templates.R2/TemplateR2Base.cs
@@ -64,16 +64,29 @@ namespace Sdl.Web.Tridion.Templates.R2
         /// <returns>List of schema identifiers</returns>
         protected List<string> GetSchemasForRichTextEmbed()
         {
-            Logger.Info("Checking 'schemasToEmbedInRichText' template parameter for list of schema identifiers to determine what entities to embed in Rich Text fields.");
-            string schemasForEmbed;
-            List<string> schemasForEmbedList = new List<string>();
-            TryGetParameter("schemasToEmbedInRichText", out schemasForEmbed);
-            if (!string.IsNullOrEmpty(schemasForEmbed))
+            return GetListFromStringParameter("schemasToEmbedInRichText");
+        }
+        /// <summary>
+        /// Gets a list of schema identifiers to determine what binaries can be published with 'as is' Urls (without tcmUri being appended).
+        /// </summary>
+        /// <returns>List of schema identifiers</returns>
+
+        protected List<string> GetSchemasForAsIsMultimediaUrls()
+        {
+            return GetListFromStringParameter("schemasForAsIsMultimediaUrls");
+        }
+        protected List<string> GetListFromStringParameter(string parameterName)
+        {
+            Logger.Info($"Checking '{parameterName}' template parameter");
+            string parameterValue;
+            List<string> parameterList = new List<string>();
+            TryGetParameter(parameterName, out parameterValue);
+            if (!string.IsNullOrEmpty(parameterValue))
             {
-                Logger.Info($"schemasToEmbedInRichText set to '{schemasForEmbed}'.");
-                schemasForEmbedList = schemasForEmbed.Split(';').Select(s => s.Trim()).ToList();
+                Logger.Info($"parameter value set to '{parameterValue}'.");
+                parameterList = parameterValue.Split(';').Select(s => s.Trim().ToLower()).ToList();
             }
-            return schemasForEmbedList;
+            return parameterList;
         }
     }
 }

--- a/Sdl.Web.Tridion.Templates.R2/Templates/GenerateEntityModel.cs
+++ b/Sdl.Web.Tridion.Templates.R2/Templates/GenerateEntityModel.cs
@@ -34,7 +34,7 @@ namespace Sdl.Web.Tridion.Templates.R2.Templates
 
             int expandLinkDepth;
             package.TryGetParameter("expandLinkDepth", out expandLinkDepth, Logger);
-            
+
             string[] modelBuilderTypeNames = GetModelBuilderTypeNames();
 
             RenderedItem renderedItem = Engine.PublishingContext.RenderedItem;
@@ -47,14 +47,15 @@ namespace Sdl.Web.Tridion.Templates.R2.Templates
                 {
                     ExpandLinkDepth = expandLinkDepth,
                     GenerateXpmMetadata = IsXpmEnabled || IsPreview,
-                    SchemasForRichTextEmbed = GetSchemasForRichTextEmbed()
+                    SchemasForRichTextEmbed = GetSchemasForRichTextEmbed(),
+                    SchemasForAsIsMultimediaUrls = GetSchemasForAsIsMultimediaUrls()
                 };
 
                 DataModelBuilderPipeline modelBuilderPipeline = new DataModelBuilderPipeline(renderedItem, settings, modelBuilderTypeNames);
                 EntityModelData entityModel = modelBuilderPipeline.CreateEntityModel(component, ct, includeComponentTemplateData);
                 OutputJson = JsonSerialize(entityModel, IsPreview, DataModelBinder.SerializerSettings);
 
-                if(string.IsNullOrEmpty(OutputJson))
+                if (string.IsNullOrEmpty(OutputJson))
                     throw new DxaException("Output Json is empty!");
             }
             catch (Exception ex)

--- a/Sdl.Web.Tridion.Templates.R2/Templates/GeneratePageModel.cs
+++ b/Sdl.Web.Tridion.Templates.R2/Templates/GeneratePageModel.cs
@@ -8,7 +8,7 @@ using Tridion.ContentManager.Templating;
 using Tridion.ContentManager.Templating.Assembly;
 
 namespace Sdl.Web.Tridion.Templates.R2.Templates
-{   
+{
     /// <summary>
     /// Generates a DXA R2 Data Model based on the current Page
     /// </summary>
@@ -40,7 +40,8 @@ namespace Sdl.Web.Tridion.Templates.R2.Templates
                     ExpandLinkDepth = expandLinkDepth,
                     GenerateXpmMetadata = IsXpmEnabled || IsPreview,
                     Locale = GetLocale(),
-                    SchemasForRichTextEmbed = GetSchemasForRichTextEmbed()
+                    SchemasForRichTextEmbed = GetSchemasForRichTextEmbed(),
+                    SchemasForAsIsMultimediaUrls = GetSchemasForAsIsMultimediaUrls()
                 };
 
                 DataModelBuilderPipeline modelBuilderPipeline = new DataModelBuilderPipeline(renderedItem, settings, modelBuilderTypeNames);


### PR DESCRIPTION
This pull request introduces enhanced flexibility for generating binary filenames, specifically addressing the need to exclude the TCM URI for certain schemas, such as PDF downloads.

The necessity for this enhancement stems from user feedback indicating that the default behavior of appending the TCM URI to the binary filenames is not practical for documents intended for download and local storage. Clean and concise filenames are particularly sought after for PDF documents.

Enhancements have been introduced in the DefaultModelBuilder and DataModelBuilder classes to facilitate this requirement. These include conditional logic that omits the TCM URI from the filename when the RenderedItem.AddBinary method is called. The method's overloads, which allow specifying a custom filename, are employed for schemas that have been configured to exclude the TCM URI.

This new functionality ensures a more user-friendly experience and grants content managers the flexibility to define clean filenames for specific schemas. The implementation is designed to be backward compatible, preserving the default behavior for all schemas that do not necessitate a deviation from the standard naming convention.

**Key Changes**:

- Conditional logic has been incorporated to manage TCM URI exclusion based on schema configuration.
- RenderedItem.AddBinary method overloads are now leveraged for customizable filename output.
- Provision of configuration options for schemas that require filenames without TCM URIs.
- Comprehensive tests have been conducted to confirm that the new logic accurately generates filenames in both default and custom scenarios. 